### PR TITLE
[ ebony, jee ] - Step2 사진앨범 접근

### DIFF
--- a/PhotoAlbum/PhotoAlbum.xcodeproj/project.pbxproj
+++ b/PhotoAlbum/PhotoAlbum.xcodeproj/project.pbxproj
@@ -16,6 +16,10 @@
 		7240385E27E865DE000E29AB /* PhotoAlbumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7240385D27E865DE000E29AB /* PhotoAlbumTests.swift */; };
 		7240386827E865DF000E29AB /* PhotoAlbumUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7240386727E865DF000E29AB /* PhotoAlbumUITests.swift */; };
 		7240386A27E865DF000E29AB /* PhotoAlbumUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7240386927E865DF000E29AB /* PhotoAlbumUITestsLaunchTests.swift */; };
+		72481D7027EAC2E100C74107 /* PhotoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72481D6F27EAC2E100C74107 /* PhotoManager.swift */; };
+		7267392427E9A45600D22C5A /* NavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7267392327E9A45600D22C5A /* NavigationController.swift */; };
+		7267392627E9A79600D22C5A /* PhotoLibraryPermission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7267392527E9A79600D22C5A /* PhotoLibraryPermission.swift */; };
+		7267392827E9B3C300D22C5A /* ImageViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7267392727E9B3C300D22C5A /* ImageViewCell.swift */; };
 		7305DDF327E96A9D0096A087 /* ColorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7305DDF227E96A9D0096A087 /* ColorFactory.swift */; };
 		7305DDF527E970090096A087 /* CollectionViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7305DDF427E970090096A087 /* CollectionViewDelegate.swift */; };
 /* End PBXBuildFile section */
@@ -51,6 +55,10 @@
 		7240386327E865DF000E29AB /* PhotoAlbumUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PhotoAlbumUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7240386727E865DF000E29AB /* PhotoAlbumUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoAlbumUITests.swift; sourceTree = "<group>"; };
 		7240386927E865DF000E29AB /* PhotoAlbumUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoAlbumUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		72481D6F27EAC2E100C74107 /* PhotoManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoManager.swift; sourceTree = "<group>"; };
+		7267392327E9A45600D22C5A /* NavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationController.swift; sourceTree = "<group>"; };
+		7267392527E9A79600D22C5A /* PhotoLibraryPermission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibraryPermission.swift; sourceTree = "<group>"; };
+		7267392727E9B3C300D22C5A /* ImageViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewCell.swift; sourceTree = "<group>"; };
 		7305DDF227E96A9D0096A087 /* ColorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorFactory.swift; sourceTree = "<group>"; };
 		7305DDF427E970090096A087 /* CollectionViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -107,11 +115,15 @@
 				7240384827E865DD000E29AB /* SceneDelegate.swift */,
 				7240384A27E865DD000E29AB /* ViewController.swift */,
 				7305DDF427E970090096A087 /* CollectionViewDelegate.swift */,
+				7267392327E9A45600D22C5A /* NavigationController.swift */,
 				7240384C27E865DD000E29AB /* Main.storyboard */,
 				7305DDF227E96A9D0096A087 /* ColorFactory.swift */,
 				7240384F27E865DE000E29AB /* Assets.xcassets */,
 				7240385127E865DE000E29AB /* LaunchScreen.storyboard */,
 				7240385427E865DE000E29AB /* Info.plist */,
+				7267392527E9A79600D22C5A /* PhotoLibraryPermission.swift */,
+				7267392727E9B3C300D22C5A /* ImageViewCell.swift */,
+				72481D6F27EAC2E100C74107 /* PhotoManager.swift */,
 			);
 			path = PhotoAlbum;
 			sourceTree = "<group>";
@@ -265,7 +277,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				7240384B27E865DD000E29AB /* ViewController.swift in Sources */,
+				7267392427E9A45600D22C5A /* NavigationController.swift in Sources */,
 				7240384727E865DD000E29AB /* AppDelegate.swift in Sources */,
+				72481D7027EAC2E100C74107 /* PhotoManager.swift in Sources */,
+				7267392627E9A79600D22C5A /* PhotoLibraryPermission.swift in Sources */,
+				7267392827E9B3C300D22C5A /* ImageViewCell.swift in Sources */,
 				7305DDF527E970090096A087 /* CollectionViewDelegate.swift in Sources */,
 				7305DDF327E96A9D0096A087 /* ColorFactory.swift in Sources */,
 				7240384927E865DD000E29AB /* SceneDelegate.swift in Sources */,
@@ -447,6 +463,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PhotoAlbum/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -474,6 +491,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PhotoAlbum/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/PhotoAlbum/PhotoAlbum/Base.lproj/Main.storyboard
+++ b/PhotoAlbum/PhotoAlbum/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="7sL-aj-5Vz">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="djd-jg-a7h">
-                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="ztx-BC-CQA">
                                     <size key="itemSize" width="128" height="128"/>
@@ -27,7 +27,7 @@
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="randomColorCell" id="SL0-v4-T0K">
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="imageViewCell" id="SL0-v4-T0K" customClass="ImageViewCell" customModule="PhotoAlbum" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="zt7-Wa-hSa">
@@ -47,13 +47,32 @@
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="djd-jg-a7h" secondAttribute="bottom" id="l0R-Hu-hZu"/>
                         </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="ZZG-Pg-XWr"/>
                     <connections>
                         <outlet property="collectionView" destination="djd-jg-a7h" id="8Ij-v7-mg2"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="20" y="94"/>
+            <point key="canvasLocation" x="928.98550724637687" y="93.75"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="bqh-Mg-dZr">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="7sL-aj-5Vz" customClass="NavigationController" customModule="PhotoAlbum" customModuleProvider="target" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="1pc-P1-mRH">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="gW1-Gz-CBD"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="x9L-9I-Gwk" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="18.840579710144929" y="93.75"/>
         </scene>
     </scenes>
     <resources>

--- a/PhotoAlbum/PhotoAlbum/CollectionViewDelegate.swift
+++ b/PhotoAlbum/PhotoAlbum/CollectionViewDelegate.swift
@@ -7,12 +7,40 @@
 
 import Foundation
 import UIKit
+import Photos
 
 class CollectionViewDelegate: NSObject {
     private let colorFactory: ColorRGBMakeable
+    private lazy var imageManager = PHCachingImageManager()
+    private var photoManager: PhotoManager?
+    private let customSize: CGSize = CGSize(width: 100, height: 100)
+    
+    private var collectionView: UICollectionView?
+    
+    private var photoResult: PHFetchResult<PHAsset>? {
+        didSet{
+            photoAssets = []
+            guard let photosCount = photoResult?.count else { return }
+            for i in 0 ..< photosCount{
+                guard let photoResult = photoResult else {
+                    return
+                }
+                photoAssets.append(photoResult.object(at: i))
+            }
+        }
+    }
+    private var photoAssets: [PHAsset] = []
+    private let options = PHImageRequestOptions()
     
     init(colorFactory: ColorRGBMakeable) {
         self.colorFactory = colorFactory
+        super.init()
+        photoManager = PhotoManager(delegate: self)
+        options.isSynchronous = true
+    }
+    
+    func setImageManager(imageManager: PHCachingImageManager){
+        self.imageManager = imageManager
     }
     
     private func randomBackgroundColor() -> UIColor{
@@ -26,21 +54,39 @@ class CollectionViewDelegate: NSObject {
 extension CollectionViewDelegate: UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        let maxCellCount = 40
-        return maxCellCount
+        return photoAssets.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let cellId = "randomColorCell"
-        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellId, for: indexPath)
+        let cellId = "imageViewCell"
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellId, for: indexPath) as? ImageViewCell else {
+            return UICollectionViewCell()
+        }
+        cell.awakeFromNib()
+        imageManager.requestImage(for: photoAssets[indexPath.item], targetSize: customSize, contentMode: .aspectFit, options: options) { image, _ in
+            cell.imageView.image = image
+        }
+        cell.setImageViewSize(size: customSize)
         cell.backgroundColor = randomBackgroundColor()
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let defaultWidth = 80
-        let defaultHeight = 80
-        return .init(width: defaultWidth, height: defaultHeight)
+        self.collectionView = collectionView
+        return customSize
+    }
+}
+
+extension CollectionViewDelegate: PhotoManagerDelegate{
+    func sendPhotoChange(change: PHFetchResult<PHAsset>) {
+        self.photoResult = change
+        DispatchQueue.main.async {
+            self.collectionView?.reloadData()
+        }
     }
     
+    func sendAssets(allPhotos: PHFetchResult<PHAsset>) {
+        self.photoResult = allPhotos
+        imageManager.startCachingImages(for: photoAssets, targetSize: customSize, contentMode: .aspectFill, options: options)
+    }
 }

--- a/PhotoAlbum/PhotoAlbum/ImageViewCell.swift
+++ b/PhotoAlbum/PhotoAlbum/ImageViewCell.swift
@@ -1,0 +1,26 @@
+//
+//  ImageViewCell.swift
+//  PhotoAlbum
+//
+//  Created by 김동준 on 2022/03/22.
+//
+
+import Foundation
+import UIKit
+
+class ImageViewCell: UICollectionViewCell{
+    lazy var imageView = UIImageView()
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        imageView.contentMode = .scaleAspectFill
+        contentView.addSubview(imageView)
+    }
+    
+    func setImageViewSize(size: CGSize){
+        imageView.frame.size = size
+    }
+}

--- a/PhotoAlbum/PhotoAlbum/Info.plist
+++ b/PhotoAlbum/PhotoAlbum/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>&quot;사진앱의 사진들을 확인할 수 있습니다.&quot;</string>
+	<key>NSCameraUsageDescription</key>
+	<string>&quot;카메라촬영이 가능합니다.&quot;</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/PhotoAlbum/PhotoAlbum/NavigationController.swift
+++ b/PhotoAlbum/PhotoAlbum/NavigationController.swift
@@ -1,0 +1,19 @@
+//
+//  NavigationController.swift
+//  PhotoAlbum
+//
+//  Created by 김동준 on 2022/03/22.
+//
+
+import Foundation
+import UIKit
+
+class NavigationController: UINavigationController{
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.navigationBar.topItem?.title = "photos"
+        
+    }
+    
+}

--- a/PhotoAlbum/PhotoAlbum/PhotoLibraryPermission.swift
+++ b/PhotoAlbum/PhotoAlbum/PhotoLibraryPermission.swift
@@ -1,0 +1,56 @@
+//
+//  PhotoLibraryPermission.swift
+//  PhotoAlbum
+//
+//  Created by 김동준 on 2022/03/22.
+//
+
+import Foundation
+import Photos
+
+protocol PhotoLibraryPermissionDelegate{
+    func accept()
+    func failed()
+}
+
+struct PhotoLibraryPermission{
+    private let permissionDelegate: PhotoLibraryPermissionDelegate
+    init(permissionDelegate: PhotoLibraryPermissionDelegate){
+        self.permissionDelegate = permissionDelegate
+    }
+    
+    func checkPermission() {
+        let photoAuthStatus = PHPhotoLibrary.authorizationStatus()
+        switch photoAuthStatus {
+        case .notDetermined:
+            requestAuth()
+        case .restricted:
+            requestAuth()
+        case .denied:
+            // 권한 거절
+            break
+        case .authorized:
+            permissionDelegate.accept()
+        case .limited:
+            permissionDelegate.accept()
+        @unknown default:
+            break
+        }
+    }
+    
+    private func requestAuth(){
+        PHPhotoLibrary.requestAuthorization( { status in
+            switch status{
+            case .authorized:
+                permissionDelegate.accept()
+            case .denied:
+                permissionDelegate.failed()
+            case .restricted, .notDetermined:
+                permissionDelegate.failed()
+            default:
+                break
+            }
+        })
+    }
+    
+}

--- a/PhotoAlbum/PhotoAlbum/PhotoManager.swift
+++ b/PhotoAlbum/PhotoAlbum/PhotoManager.swift
@@ -1,0 +1,44 @@
+//
+//  PhotoManager.swift
+//  PhotoAlbum
+//
+//  Created by 김동준 on 2022/03/23.
+//
+
+import Foundation
+import Photos
+
+protocol PhotoManagerDelegate{
+    func sendAssets(allPhotos: PHFetchResult<PHAsset>)
+    func sendPhotoChange(change: PHFetchResult<PHAsset>)
+}
+
+class PhotoManager: NSObject{
+    private let allPhotos: PHFetchResult<PHAsset>?
+    private var assets: [PHAsset] = []
+    private var delegate: PhotoManagerDelegate?
+    init(delegate: PhotoManagerDelegate){
+        allPhotos = PHAsset.fetchAssets(with: nil)
+        super.init()
+        self.delegate = delegate
+        self.setAssets()
+        PHPhotoLibrary.shared().register(self)
+    }
+    
+    private func setAssets(){
+        guard let allPhotos = self.allPhotos else { return }
+        for i in 0 ..< allPhotos.count{
+            assets.append(allPhotos.object(at: i))
+        }
+        delegate?.sendAssets(allPhotos: allPhotos)
+    }
+}
+
+extension PhotoManager: PHPhotoLibraryChangeObserver{
+    func photoLibraryDidChange(_ changeInstance: PHChange) {
+        guard let allPhotos = self.allPhotos else { return }
+        guard var detail = changeInstance.changeDetails(for: allPhotos) else { return }
+        let afterChanges = detail.fetchResultAfterChanges
+        delegate?.sendPhotoChange(change: afterChanges)
+    }
+}

--- a/PhotoAlbum/PhotoAlbum/ViewController.swift
+++ b/PhotoAlbum/PhotoAlbum/ViewController.swift
@@ -6,6 +6,8 @@
 //
 
 import UIKit
+import Photos
+import AVFoundation
 
 class ViewController: UIViewController {
 
@@ -14,10 +16,25 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        checkLibraryPermission()
+        
         collectionView.delegate = collectionViewDelegate
         collectionView.dataSource = collectionViewDelegate
     }
-
-
+    
+    private func checkLibraryPermission(){
+        let photoLibraryPermission = PhotoLibraryPermission(permissionDelegate: self)
+        photoLibraryPermission.checkPermission()
+    }
+    
 }
 
+extension ViewController: PhotoLibraryPermissionDelegate{
+    func accept() {
+        collectionView.reloadData()
+    }
+    
+    func failed() {
+        print("permission failed")
+    }
+}


### PR DESCRIPTION
💁 진행완료
- [x] Info.plist를 통하여 권한요청 설정추가.
- [x] 콜랙션뷰에 커스텀 셀 추가.
- [x] 사진보관함(카메라롤) 사진들을 CollectionView로 표시.
- [x] PHPhotoLibrary 클래스에 사진보관함이 변경되는지 여부를 옵저버로 등록 후 변경 시 컬렉션 뷰 업데이트.
- [x] UINavigationController를 Embed

👨‍💻 학습키워드
- Photo
- AVFoundation
- photos 객체 ( PHFetchResult, PHAsset, PHCachingImageManager, PHPhotoLibraryChangeObserver )
- CollectionView (CustomCell 생성, reloadData(변경데이터 업데이트))

👀 고민과 해결
사진앱 변경 감지 시 CollectionView의 업데이트를 하였는 데, 변경 사진들을 포함하여 기존의 사진들이 CollectionView에 표시됨.
- [PHAsset] 배열을 초기화 하지 않고 덧붙여서 났던 오류였습니다.

😁 느낀점
[ Jee ]
1. 한 문제를 해결하려 끝까지 노력하지 않았는 데 이와 같이 학습하여보니 배우는 내용이 많다고 느꼈다.
[ ebony ]
1. 기능을 구현하며 코드까지 깔끔하게 구현하려 하였지만 결국 클린코드는 놓치고 지나가는 부분이 많았다.
2. 문제가 생긴 부분을 너무 어렵게 생각하지 않으려 해야겠다.. 